### PR TITLE
Safety checks for aws_array_list

### DIFF
--- a/.cbmc-batch/array_list_proofs.c
+++ b/.cbmc-batch/array_list_proofs.c
@@ -6,9 +6,6 @@
 #include <stdarg.h>
 #include <proof_helpers.h>
 
-#define MAX_INITIAL_ITEM_ALLOCATION 2
-#define MAX_ITEM_SIZE 15
-
 void aws_array_list_init_dynamic_verify(void) {
     struct aws_array_list *list;
     ASSUME_VALID_MEMORY(list);
@@ -18,7 +15,7 @@ void aws_array_list_init_dynamic_verify(void) {
     size_t item_size = nondet_size_t();
 
     aws_array_list_init_dynamic(list, allocator, item_count, item_size);
-    
+
     /* some guarantees */
     assert(list->alloc == allocator);
     assert(list->item_size == item_size);
@@ -38,7 +35,7 @@ void aws_array_list_init_static_verify(void) {
 
 
     aws_array_list_init_static(list, raw_array, item_count, item_size);
-    
+
     /* some guarantees */
     assert(list->alloc == NULL);
     assert(list->item_size == item_size);
@@ -46,18 +43,18 @@ void aws_array_list_init_static_verify(void) {
 }
 
 void aws_array_list_set_at_verify(void) {
-    size_t initial_item_allocation = nondet_size_t();
-    __CPROVER_assume(initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
     size_t item_size = nondet_size_t();
     __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
     struct aws_array_list *list;
-    ASSUME_ARBITRARY_ARRAY_LIST(list, initial_item_allocation, item_size);
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
 
     void *val = malloc(item_size);
 
     size_t index = nondet_size_t();
     __CPROVER_assume(index < __CPROVER_constant_infinity_uint - 1);
-    
+
     aws_array_list_set_at(list, val, index);
 }
 
@@ -69,7 +66,146 @@ void aws_array_list_push_back_verify(void) {
     struct aws_array_list *list;
     ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
 
+    size_t len = list->length;
     void *val = malloc(item_size);
 
     aws_array_list_push_back(list, val);
+
+    /* some guarantees */
+    assert(list->length == len + 1);
+}
+
+void aws_array_list_back_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    void *val = malloc(item_size);
+
+    aws_array_list_back(list, val);
+}
+
+void aws_array_list_clean_up_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    aws_array_list_clean_up(list);
+
+    /* some guarantees */
+    assert(list->length == 0);
+    assert(list->alloc == NULL);
+    assert(list->current_size == 0);
+    assert(list->item_size == 0);
+    assert(list->data == NULL);
+}
+
+void aws_array_list_clear_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    size_t prev_current_size = list->current_size;
+    size_t prev_item_size = list->item_size;
+    void* prev_data = list->data;
+
+    aws_array_list_clear(list);
+
+    /* some guarantees */
+    assert(list->length == 0);
+    assert(list->current_size == prev_current_size);
+    assert(list->item_size == prev_item_size);
+    assert(list->data == prev_data);
+}
+
+void aws_array_list_front_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    void *val = malloc(item_size);
+
+    aws_array_list_front(list, val);
+}
+
+void aws_array_list_get_at_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    void *val = malloc(item_size);
+
+    size_t index = nondet_size_t();
+    __CPROVER_assume(index < __CPROVER_constant_infinity_uint - 1);
+    __CPROVER_assume(list->length > index);
+
+    aws_array_list_get_at(list, val, index);
+}
+
+void aws_array_list_get_at_ptr_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    void *val = malloc(item_size);
+
+     size_t index = nondet_size_t();
+    __CPROVER_assume(index < __CPROVER_constant_infinity_uint - 1);
+    __CPROVER_assume(list->length > index);
+
+    aws_array_list_get_at_ptr(list, &val, index);
+}
+
+void aws_array_list_length_verify(void) {
+    size_t item_count = nondet_size_t();
+    __CPROVER_assume(item_count <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size = nondet_size_t();
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    struct aws_array_list *list;
+    ASSUME_ARBITRARY_ARRAY_LIST(list, item_count, item_size);
+
+    size_t len = aws_array_list_length(list);
+
+    assert(len == list->length);
+}
+
+void aws_array_list_swap_contents_verify(void) {
+    size_t item_count_a = nondet_size_t();
+    __CPROVER_assume(item_count_a <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size_a = nondet_size_t();
+    __CPROVER_assume(item_size_a <= MAX_ITEM_SIZE);
+    struct aws_array_list *list_a;
+    ASSUME_ARBITRARY_ARRAY_LIST(list_a, item_count_a, item_size_a);
+
+    size_t item_count_b = nondet_size_t();
+    __CPROVER_assume(item_count_b <= MAX_INITIAL_ITEM_ALLOCATION);
+    size_t item_size_b = nondet_size_t();
+    __CPROVER_assume(item_size_b <= MAX_ITEM_SIZE);
+    struct aws_array_list *list_b;
+    ASSUME_ARBITRARY_ARRAY_LIST(list_b, item_count_b, item_size_b);
+
+    __CPROVER_assume(list_a->alloc != NULL);
+    __CPROVER_assume(list_a->alloc == list_b->alloc);
+    __CPROVER_assume(list_a->item_size == list_b->item_size);
+    __CPROVER_assume(list_a != list_b);
+
+    aws_array_list_swap_contents(list_a, list_b);
 }

--- a/.cbmc-batch/jobs/aws_array_list_back/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_back/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_back/proofs.goto \
+	--function aws_array_list_back_verify

--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_back_verify;--unwindset;strlen.0:33,memcpy.0:33,__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_clean_up/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_clean_up/proofs.goto \
+	--function aws_array_list_clean_up_verify

--- a/.cbmc-batch/jobs/aws_array_list_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_clean_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_clean_up_verify;--unwindset;aws_mem_release:1;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_clear/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_clear/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_clear/proofs.goto \
+	--function aws_array_list_clear_verify

--- a/.cbmc-batch/jobs/aws_array_list_clear/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_clear/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_clear_verify;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_front/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_front/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_front/proofs.goto \
+	--function aws_array_list_front_verify

--- a/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_front_verify;--unwindset;__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_get_at/proofs.goto \
+	--function aws_array_list_get_at_verify

--- a/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_get_at_verify;--unwindset;__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_get_at_ptr/proofs.goto \
+	--function aws_array_list_get_at_ptr_verify

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_get_at_ptr_verify;--unwindset;__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_length/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_length/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_length/proofs.goto \
+	--function aws_array_list_length_verify

--- a/.cbmc-batch/jobs/aws_array_list_length/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_length/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_length_verify;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_swap_contents/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_swap_contents/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+proofs.goto:
+	cd ../../..; \
+	goto-cc .cbmc-batch/array_list_proofs.c source/byte_buf.c \
+	source/array_list.c source/common.c source/error.c .cbmc-batch/patches/string.c \
+	-Iinclude/ -I.cbmc-batch/ -o .cbmc-batch/jobs/aws_array_list_swap_contents/proofs.goto \
+	--function aws_array_list_swap_contents_verify

--- a/.cbmc-batch/jobs/aws_array_list_swap_contents/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_swap_contents/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_swap_contents_verify;--unwinding-assertions"
+goto: proofs.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/proof_helpers.h
+++ b/.cbmc-batch/proof_helpers.h
@@ -1,5 +1,8 @@
 #include<stdlib.h>
 
+#define MAX_INITIAL_ITEM_ALLOCATION 2
+#define MAX_ITEM_SIZE 15
+
 #define ASSUME_VALID_MEMORY(ptr) ptr = malloc(sizeof(*(ptr)))
 #define ASSUME_VALID_MEMORY_COUNT(ptr, count) ptr = malloc(sizeof(*(ptr)) * (count))
 #define ASSUME_DEFAULT_ALLOCATOR(allocator) allocator = aws_default_allocator()
@@ -19,14 +22,14 @@ struct aws_array_list *get_arbitrary_array_list(size_t item_count, size_t item_s
         ASSUME_DEFAULT_ALLOCATOR(allocator);
         aws_array_list_init_dynamic(list, allocator, item_count, item_size);
     } else { /* Static initialization */
-        __CPROVER_assume(item_count > 0); 
-        __CPROVER_assume(item_size > 0); 
+        __CPROVER_assume(item_count > 0);
+        __CPROVER_assume(item_size > 0);
 
         size_t len = item_count * item_size;
         void *raw_array = malloc(len);
 
         aws_array_list_init_static(list, raw_array, item_count, item_size);
-    }   
+    }
 
     return list;
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

This PR contains proofs for the following functions of `array_list.h`:

`aws_array_list_back`
`aws_array_list_clean_up`
`aws_array_list_clear`
`aws_array_list_front`
`aws_array_list_get_at`
`aws_array_list_get_at_ptr`
`aws_array_list_length`
`aws_array_list_swap_contents`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
